### PR TITLE
FIX: rtd build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,29 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+    # You can also specify other tool versions:
+    # nodejs: "19"
+    # rust: "1.64"
+    # golang: "1.19"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/conf.py
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+# formats:
+#    - pdf
+
+# Optionally declare the Python requirements required to build your docs
+python:
+   install:
+   - requirements: docs/requirements.txt


### PR DESCRIPTION
TLDR, the current readthedocs build was broken due to an update in urllib. It was not noticed since the repository wasn't updated in a while and therefore didn't trigger any build.

The fix: urlllib requires openssl>1.1.1 [1] which was not available with the current python 3.7 setup. I bumped the python version to 3.11 which includes the latest openssl version. Python dependencies are... fun.

[1] https://github.com/urllib3/urllib3/issues/2168